### PR TITLE
Resolves #16

### DIFF
--- a/View/Helper/RecaptchaHelper.php
+++ b/View/Helper/RecaptchaHelper.php
@@ -74,7 +74,7 @@ class RecaptchaHelper extends AppHelper {
 
 		$options = Set::merge($defaults, $options);
 		extract($options);
-
+                
 		if ($ssl) {
 			$server = $this->secureApiUrl;
 		} else {
@@ -101,7 +101,7 @@ class RecaptchaHelper extends AppHelper {
 
 		if (empty($this->params['isAjax'])) {
 			$configScript = sprintf('var RecaptchaOptions = %s', $jsonOptions);
-			$this->Html->scriptBlock($configScript, array('inline' => false));
+			echo $this->Html->scriptBlock($configScript);
 
 			$script = '<script type="text/javascript" src="'. $server . '/challenge?k=' . $publicKey . '"></script>
 				<noscript>


### PR DESCRIPTION
Updated the config script to output before the form element as per the docs.

> To make the reCAPTCHA widget display a different theme, you first need to add the following code in your main HTML page anywhere before the <form> element where reCAPTCHA appears (this will not work if placed after the main script where reCAPTCHA is first invoked):
