### PR TITLE
RecaptchaComponent::verify() does not always return

### DIFF
--- a/Controller/Component/RecaptchaComponent.php
+++ b/Controller/Component/RecaptchaComponent.php
@@ -160,8 +160,10 @@ class RecaptchaComponent extends Component {
 				$this->error = $response[1];
 			}
 
-			return false;
+
 		}
+		
+		return false;
 	}
 
 /**


### PR DESCRIPTION
Placed the default return false; at the end of the function so that it is executed even if recaptcha_challenge_field or recaptcha_response_field are not set.
