### PR TITLE
Use strict comparison

### DIFF
--- a/Controller/Component/RecaptchaComponent.php
+++ b/Controller/Component/RecaptchaComponent.php
@@ -71,7 +71,7 @@ class RecaptchaComponent extends Component {
 		'errorField' => 'recaptcha',
 		'actions' => array()
 	);
- 
+
  /**
  * Constructor
  *
@@ -97,7 +97,7 @@ class RecaptchaComponent extends Component {
  * @return void
  */
 	public function initialize(Controller $controller, $settings = array()) {
-		if ($controller->name == 'CakeError') {
+		if ($controller->name === 'CakeError') {
 			return;
 		}
 		$this->privateKey = Configure::read('Recaptcha.privateKey');
@@ -154,11 +154,11 @@ class RecaptchaComponent extends Component {
 				return false;
 			}
 
-			if ($response[0] == 'true') {
+			if ($response[0] === 'true') {
 				return true;
 			}
 
-			if ($response[1] == 'incorrect-captcha-sol') {
+			if ($response[1] === 'incorrect-captcha-sol') {
 				$this->error = __d('recaptcha', 'Incorrect captcha', true);
 			} else {
 				$this->error = $response[1];


### PR DESCRIPTION
I would advise to use strict comparison. In the past I stumbled upon some string quirks. For instance:

```
var_dump (array(
0 == 'failure', // true
));
```
